### PR TITLE
Config Sidekiq, Redis For Heroku Production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-processworker: bundle exec sidekiq -c 2
+web: bundle exec puma -C config/puma.rb
+processworker: bundle exec sidekiq -t 25 -e production -C config/sidekiq.yml

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,24 @@
+if Rails.env.production?
+
+  Sidekiq.configure_client do |config|
+    config.redis = { url: ENV['REDISTOGO_URL'] || ENV['REDIS_URL'], size: 1 }
+  end
+
+  Sidekiq.configure_server do |config|
+    pool_size = ENV['SIDEKIQ_DB_POOL'] || (Sidekiq.options[:concurrency] + 2)
+    config.redis = { url: ENV['REDISTOGO_URL'] || ENV['REDIS_URL'], size: pool_size }
+
+    Rails.application.config.after_initialize do
+      Rails.logger.info("DB Connection Pool size for Sidekiq Server before disconnect is: #{ActiveRecord::Base.connection.pool.instance_variable_get('@size')}")
+      ActiveRecord::Base.connection_pool.disconnect!
+
+      ActiveSupport.on_load(:active_record) do
+        db_config = Rails.application.config.database_configuration[Rails.env]
+        db_config['reaping_frequency'] = ENV['DATABASE_REAP_FREQ'] || 10 # seconds
+        db_config['pool'] = pool_size
+        ActiveRecord::Base.establish_connection(db_config)
+        Rails.logger.info("DB Connection Pool size for Sidekiq Server is now: #{ActiveRecord::Base.connection.pool.instance_variable_get('@size')}")
+      end
+    end
+  end
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,6 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 threads threads_count, threads_count
 
@@ -36,9 +37,9 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # recommended that you close any connections to the database before workers
 # are forked to prevent connection leakage.
 #
-# before_fork do
-#   ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
-# end
+before_fork do
+  ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+end
 
 # The code in the `on_worker_boot` will be called if you are using
 # clustered mode by specifying a number of `workers`. After each worker
@@ -47,10 +48,10 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # or connections that may have been created at application boot, as Ruby
 # cannot share connections between processes.
 #
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
-#
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
+
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,6 @@
+development:
+  :concurrency: 5
+production:
+  :concurrency: 6
+:queues:
+  - default


### PR DESCRIPTION
Config Puma, Sidekiq w/ Redis for Heroku Production

following example

`http://aleksandr-rogachev-blog.com/2017/07/25/effective_deployment_of_rails_app_to_heroku_with_sidekiq_and_puma/`